### PR TITLE
Added option to split output into smaller chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 brickdiff
-
 dist/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ Available Commands:
   add         Adds two BrickLink Wanted lists in XML format
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command
+  id          Idenity function: output list will be the same as the input list
   intersect   Creates the intersection of two BrickLink Wanted lists in XML format
   multiply    Multiplies the quantity of all parts in BrickLink Wanted list with a given factor
   subtract    Subtracts two BrickLink Wanted lists in XML format
   union       Creates the union of two BrickLink Wanted lists in XML format
 
 Flags:
+  -l, --chunksize int    Maximum chunk size limit for the output files. Longer lists will be split into several files. Can not be combined with the clipboard option
   -c, --clipboard        Copy output to clipboard (default)
   -h, --help             help for brickdiff
   -m, --multiline        Multiline output (default is compact output)
@@ -191,7 +193,31 @@ Global Flags:
   -s, --stdout           Print output to console (stdout)
 ```
 
-# Example
+## Identity function
+
+To allow for splitting a list without performing any transformation function, the `id` function was added. But it also can serve to just validate an XML file.
+
+```
+> brickdiff id --help
+Parses the input list and outputs it again.
+        Can be used to split up a list in conjunction with the --chunksize/-l option.
+        Can be used to validate the format of the input list.
+
+Usage:
+  brickdiff id bricklist [flags]
+
+Flags:
+  -h, --help   help for id
+
+Global Flags:
+  -l, --chunksize int    Maximum chunk size limit for the output files. Longer lists will be split into several files. Can not be combined with the clipboard option
+  -c, --clipboard        Copy output to clipboard (default)
+  -m, --multiline        Multiline output (default is compact output)
+  -o, --outfile string   Name of output file
+  -s, --stdout           Print output to console (stdout)
+```
+
+# Examples
 
 Let's assume that you have the parts for my [Funny Birds: Chicken](https://rebrickable.com/mocs/MOC-71294/olivercgoetz/funny-birds-chicken/#details). 
 
@@ -224,9 +250,28 @@ You should see an output like:
 Output copied to clipboard.
 ```
 
+## Splitting a list in smaller chunks
+
+Sometimes it's useful to split up a long list into smaller chunks. For example, when ordering from the LEGO "Pick a Brick" service, there is a limit of how many lots can be added in one order. To that end, there is an output option `--chunkzize` that limits the number of lots to include in each output XML document. When using in conjunction with the `--outfile` output option, this will result in several files with a trailing number (starting with 1) in case the result list is longer than the chunksize.
+
+```
+> brickdiff id examples/rooster.xml --chunksize 10 --outfile rooster-chunk.xml
+Output written to file rooster-chunk-1.xml
+Output written to file rooster-chunk-2.xml
+Output written to file rooster-chunk-3.xml
+```
+
+This will create three XML files with 10, 10 and 1 lot (the original file has 21 lots):
+```
+> ls -l rooster-chunk-* 
+-rw-r--r--  1 olivergotz  staff  976 Jun 11 14:16 rooster-chunk-1.xml
+-rw-r--r--  1 olivergotz  staff  969 Jun 11 14:16 rooster-chunk-2.xml
+-rw-r--r--  1 olivergotz  staff  158 Jun 11 14:16 rooster-chunk-3.xml
+```
+
 ## Uploading the parts list to BrickLink
 
-To create the new wanted list with the result:
+To create the new wanted list on Bricklink with the result from `brickdiff`:
 
 1. Go to the [BrickLink Wanted List Upload Page](https://www.bricklink.com/v2/wanted/upload.page?utm_content=subnav)
 1. Click on _Upload BrickLink XML format_
@@ -236,5 +281,12 @@ To create the new wanted list with the result:
 1. Click on _Proceed to verify items_. You should now see the list of parts with preview pictures.
 1. Click on _Add to Wanted List_
 
+## Ordering parts from LEGO Pick a Brick
+
+The XML files cannot be directly uploaded to the _LEGO Pick a Brick_ service for ordering single parts, as this service is designed to be used interactively in a web browser.
+
+Fortunately, other talented LEGO fans have developed a browser plugin [BrickHunter](https://github.com/BrickTwo/BrickHunter) which can import brick lists in different formats, including the Bricklink XML format. BrickHunter is an open source project, and you can install the plugin for Google Chrome, Microsoft Edge and Mozilla Firefox browsers from their respective extensions store.
+
+Note that you might need to split up longer wanted lists, as there are limitations how many lots can be ordered at once from LEGO. The BrickHunter pluging will just report a warning that the list was not transferred to the LEGO shopping cart.
 
 

--- a/bricklist/inventory.go
+++ b/bricklist/inventory.go
@@ -47,6 +47,21 @@ func getKey(item Item) ItemKey {
 	}
 }
 
+func splitInventory(inventory Inventory, chunkSize int) []Inventory {
+	if chunkSize < 1 {
+		return []Inventory{inventory}
+	}
+	numberOfItems := len(inventory.Items)
+	numberOfChunks := (numberOfItems-1)/chunkSize + 1
+	inventories := make([]Inventory, numberOfChunks)
+	for i := 0; i < numberOfChunks; i++ {
+		inventoryChunk := Inventory{}
+		inventoryChunk.Items = inventory.Items[i*chunkSize : min((i+1)*chunkSize, numberOfItems)]
+		inventories[i] = inventoryChunk
+	}
+	return inventories
+}
+
 func PrintInventory(inventory Inventory) {
 	for i := 0; i < len(inventory.Items); i++ {
 		fmt.Println("ITEMTYPE: " + inventory.Items[i].ItemType)

--- a/bricklist/xmlhandler.go
+++ b/bricklist/xmlhandler.go
@@ -29,7 +29,16 @@ func ReadXmlList(filename string) Inventory {
 	return inventory
 }
 
-func RenderXML(inventory Inventory, multiline bool) string {
+func RenderXML(inventory Inventory, multiline bool, chunkSize int) []string {
+	var xmlStrings []string
+	inventoryChunks := splitInventory(inventory, chunkSize)
+	for i := 0; i < len(inventoryChunks); i++ {
+		xmlStrings = append(xmlStrings, RenderSingleXML(inventoryChunks[i], multiline))
+	}
+	return xmlStrings
+}
+
+func RenderSingleXML(inventory Inventory, multiline bool) string {
 	tmp := struct {
 		Inventory
 		XMLName struct{} `xml:"INVENTORY"`

--- a/bricklist/xmlhandler_test.go
+++ b/bricklist/xmlhandler_test.go
@@ -63,7 +63,7 @@ func TestReadXmlList(t *testing.T) {
 func TestRenderXmlMultiline(t *testing.T) {
 	inventory := Inventory{Items: []Item{item1, item2, item3, item4}}
 	expectedXml := readFile(t, "../testdata/four_items.xml")
-	renderedXml := RenderXML(inventory, true)
+	renderedXml := RenderSingleXML(inventory, true)
 	if renderedXml != expectedXml {
 		t.Fatalf(`Expected xml: "%v", but got "%v".`, expectedXml, renderedXml)
 	}
@@ -74,7 +74,7 @@ func TestRenderXmlSingleline(t *testing.T) {
 	expectedXml := readFile(t, "../testdata/four_items.xml")
 	re := regexp.MustCompile(`\s*\n\s*`)
 	expectedXml = re.ReplaceAllString(expectedXml, "") + "\n"
-	renderedXml := RenderXML(inventory, false)
+	renderedXml := RenderSingleXML(inventory, false)
 	if renderedXml != expectedXml {
 		t.Fatalf(`Expected xml: "%v", but got "%v".`, expectedXml, renderedXml)
 	}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -36,6 +36,6 @@ func add(bricklist1 string, bricklist2 string, outOptions output.OutputOptions) 
 	inventory1 := bricklist.ReadXmlList(bricklist1)
 	inventory2 := bricklist.ReadXmlList(bricklist2)
 	result := bricklist.AddInventories(inventory1, inventory2)
-	xmlString := bricklist.RenderXML(result, outOptions.Multiline)
+	xmlString := bricklist.RenderXML(result, outOptions.Multiline, outOptions.ChunkSize)
 	output.Output(xmlString, outOptions)
 }

--- a/cmd/id.go
+++ b/cmd/id.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2022-2023 Oliver Götz <developer@geekgasm.eu>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Geekgasm/brickdiff/bricklist"
+	"github.com/Geekgasm/brickdiff/output"
+	"github.com/spf13/cobra"
+)
+
+var idCmd = &cobra.Command{
+	Use:   "id bricklist",
+	Short: "Idenity function: output list will be the same as the input list",
+	Long: `Parses the input list and outputs it again.
+	Can be used to split up a list in conjunction with the --chunksize/-l option.
+	Can be used to validate the format of the input list.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			fmt.Fprintf(os.Stderr, "One argument is required (filename of the bricklink wanted list)\n")
+			os.Exit(1)
+		}
+		id(args[0], output.GetOutputOptions(cmd.Flags()))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(idCmd)
+}
+
+func id(inputBricklist string, outOptions output.OutputOptions) {
+	inventory := bricklist.ReadXmlList(inputBricklist)
+	xmlString := bricklist.RenderXML(inventory, outOptions.Multiline, outOptions.ChunkSize)
+	output.Output(xmlString, outOptions)
+}

--- a/cmd/intersect.go
+++ b/cmd/intersect.go
@@ -35,6 +35,6 @@ func intersect(bricklist1 string, bricklist2 string, outOptions output.OutputOpt
 	inventory1 := bricklist.ReadXmlList(bricklist1)
 	inventory2 := bricklist.ReadXmlList(bricklist2)
 	result := bricklist.IntersectInventories(inventory1, inventory2)
-	xmlString := bricklist.RenderXML(result, outOptions.Multiline)
+	xmlString := bricklist.RenderXML(result, outOptions.Multiline, outOptions.ChunkSize)
 	output.Output(xmlString, outOptions)
 }

--- a/cmd/multiply.go
+++ b/cmd/multiply.go
@@ -39,6 +39,6 @@ func init() {
 func multiply(bricklinklist string, factor int, outOptions output.OutputOptions) {
 	inventory := bricklist.ReadXmlList(bricklinklist)
 	result := bricklist.Multiply(inventory, factor)
-	xmlString := bricklist.RenderXML(result, outOptions.Multiline)
+	xmlString := bricklist.RenderXML(result, outOptions.Multiline, outOptions.ChunkSize)
 	output.Output(xmlString, outOptions)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,4 +41,5 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("multiline", "m", false, "Multiline output (default is compact output)")
 	rootCmd.PersistentFlags().BoolP("stdout", "s", false, "Print output to console (stdout)")
 	rootCmd.PersistentFlags().StringP("outfile", "o", "", "Name of output file")
+	rootCmd.PersistentFlags().IntP("chunksize", "l", 0, "Maximum chunk size limit for the output files; longer lists will be split into several XML documents")
 }

--- a/cmd/subtract.go
+++ b/cmd/subtract.go
@@ -37,6 +37,6 @@ func subtract(bricklist1 string, bricklist2 string, outOptions output.OutputOpti
 	inventory1 := bricklist.ReadXmlList(bricklist1)
 	inventory2 := bricklist.ReadXmlList(bricklist2)
 	result := bricklist.SubtractInventories(inventory1, inventory2)
-	xmlString := bricklist.RenderXML(result, outOptions.Multiline)
+	xmlString := bricklist.RenderXML(result, outOptions.Multiline, outOptions.ChunkSize)
 	output.Output(xmlString, outOptions)
 }

--- a/cmd/union.go
+++ b/cmd/union.go
@@ -36,6 +36,6 @@ func union(bricklist1 string, bricklist2 string, outOptions output.OutputOptions
 	inventory1 := bricklist.ReadXmlList(bricklist1)
 	inventory2 := bricklist.ReadXmlList(bricklist2)
 	result := bricklist.UnionInventories(inventory1, inventory2)
-	xmlString := bricklist.RenderXML(result, outOptions.Multiline)
+	xmlString := bricklist.RenderXML(result, outOptions.Multiline, outOptions.ChunkSize)
 	output.Output(xmlString, outOptions)
 }


### PR DESCRIPTION
* Output option `--chunksize` / `-l`
* New identity function `id` to facilitate splitting without additional transformation